### PR TITLE
Highlight for loops, WITH NAME, token overhaul

### DIFF
--- a/src/packages/jupyterlab-robotframework/src/mode.ts
+++ b/src/packages/jupyterlab-robotframework/src/mode.ts
@@ -291,7 +291,11 @@ states.keywords = [
 ];
 
 /** A range as used in for loops */
-const RULE_RANGE = r(/([\| ]* *)(IN)( RANGE)?/, [null, 'builtin', 'builtin']);
+const RULE_RANGE = r(/([\| ]* *)(IN)( RANGE| ENUMERATE| ZIP)?/, [
+  null,
+  'builtin',
+  'builtin'
+]);
 
 states.loop_start_new = [
   RULE_RANGE,


### PR DESCRIPTION
It had been a while since I had done a thorough reading of the guide and test suite to catch more corner cases for highlighting. The most egregious oversight was for loops, which I even use in the test suite!

![screenshot from 2019-01-24 07-52-21](https://user-images.githubusercontent.com/45380/51679456-067a6a80-1fad-11e9-8dd4-a2cf1f4b138c.png)


This adds:
- `FOR`/`END` and `:FOR` loops (old and new style)
  - `IN RANGE` and friends
- tabs (they're actually pretty good with the right tab width, but still wouldn't recommend)
- Library `WITH NAME`
- generally shifted token scheme: 
  - `variable-2` for variables
  - `atom` for language constructs (`FOR`, etc)
  - `meta` for settings

I'd like to add some way to test these things, e.g. the [google-modes](https://github.com/codemirror/google-modes/tree/master/test) tests, but really would like hypothesis in the loop... so this might have to wait for another ticket, and just do more manual testing (THE IRONY).